### PR TITLE
CMake subdirectory/library build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+project(facil.io C)
+
+find_package(Threads REQUIRED)
+
+set(facil.io_SOURCES
+  src/services/pubsub.c
+  src/http/http1_simple_parser.c
+  src/http/http_request.c
+  src/http/websockets.c
+  src/http/http1_request.c
+  src/http/http_response.c
+  src/http/unused/hpack.c
+  src/http/http.c
+  src/http/http1.c
+  src/http/http1_response.c
+  src/bscrypt/bscrypt/sha1.c
+  src/bscrypt/bscrypt/hex.c
+  src/bscrypt/bscrypt/misc.c
+  src/bscrypt/bscrypt/siphash.c
+  src/bscrypt/bscrypt/random.c
+  src/bscrypt/bscrypt/base64.c
+  src/bscrypt/bscrypt/unused/mempool.c
+  src/bscrypt/bscrypt/sha2.c
+  src/bscrypt/bscrypt/xor-crypt.c
+  src/core/defer.c
+  src/core/facil.c
+  src/core/sock.c
+  src/core/evio.c
+)
+
+add_library(facil.io ${facil.io_SOURCES})
+target_link_libraries(facil.io PRIVATE Threads::Threads)
+target_include_directories(facil.io
+  PUBLIC  src/http
+  PRIVATE src/bscrypt
+  PRIVATE src/bscrypt/bscrypt
+  PUBLIC  src/core
+  PRIVATE src/core/types
+)

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -155,7 +155,7 @@ A NULL terminating byte is written.
 
 Returns the number of bytes actually written (excluding the NULL byte).
 */
-inline size_t http_ul2a(char *dest, size_t num) {
+static inline size_t http_ul2a(char *dest, size_t num) {
   uint8_t digits = 1;
   size_t tmp = num;
   while ((tmp /= 10))

--- a/src/services/pubsub.c
+++ b/src/services/pubsub.c
@@ -50,10 +50,10 @@ static fio_ht_s pubsub_patterns = FIO_HASH_TABLE_STATIC(pubsub_patterns);
 
 spn_lock_i pubsub_GIL = SPN_LOCK_INIT;
 
-inline uint64_t atomic_bump(volatile uint64_t *i) {
+static inline uint64_t atomic_bump(volatile uint64_t *i) {
   return __sync_add_and_fetch(i, 1ULL);
 }
-inline uint64_t atomic_cut(volatile uint64_t *i) {
+static inline uint64_t atomic_cut(volatile uint64_t *i) {
   return __sync_sub_and_fetch(i, 1ULL);
 }
 


### PR DESCRIPTION
First I would like to thank you for your work in creating facil.io

I wanted to be able to easily use facil.io as a dependency in my project which is built with CMake, so I have added a `CMakeLists.txt`.

To use facil.io in a CMake build you may add it as a submodule to the project's repository.
`git submodule add https://github.com/boazsegev/facil.io.git`

then add the following line the project's `CMakeLists.txt` 
`add_subdirectory(facil.io)`

Here is an example of a project that is dependant on facil.io and built with CMake.
https://github.com/OwenDelahoy/facil.io-examples

However, I did have linking problems with regards to the `inline` methods and chose to make them `static inline`, does this create any unintended consequences?
https://github.com/boazsegev/facil.io/compare/master...OwenDelahoy:master#diff-6eb3b857baf5d5a8e5cc99b6ad6939d
https://github.com/boazsegev/facil.io/compare/master...OwenDelahoy:master#diff-798158459ab3baf39579beafdfb08f3d4
