### PR TITLE
Fix tautological equality comparison and fallthrough warnings

### DIFF
--- a/lib/facil/core/types/fiobj/fio_siphash.c
+++ b/lib/facil/core/types/fiobj/fio_siphash.c
@@ -68,25 +68,24 @@ uint64_t fio_siphash(const void *data, size_t len) {
   switch (len) { /* fallthrough is intentional */
   case 7:
     pos[6] = w8[6];
-    __attribute__((fallthrough));
+    /* fallthrough */
   case 6:
     pos[5] = w8[5];
-    __attribute__((fallthrough));
+    /* fallthrough */
   case 5:
     pos[4] = w8[4];
-    __attribute__((fallthrough));
+    /* fallthrough */
   case 4:
     pos[3] = w8[3];
-    __attribute__((fallthrough));
+    /* fallthrough */
   case 3:
     pos[2] = w8[2];
-    __attribute__((fallthrough));
+    /* fallthrough */
   case 2:
     pos[1] = w8[1];
-    __attribute__((fallthrough));
+    /* fallthrough */
   case 1:
     pos[0] = w8[0];
-    __attribute__((fallthrough));
   }
   word.str[7] = len_mod;
 

--- a/lib/facil/core/types/fiobj/fio_siphash.c
+++ b/lib/facil/core/types/fiobj/fio_siphash.c
@@ -68,18 +68,25 @@ uint64_t fio_siphash(const void *data, size_t len) {
   switch (len) { /* fallthrough is intentional */
   case 7:
     pos[6] = w8[6];
+    __attribute__((fallthrough));
   case 6:
     pos[5] = w8[5];
+    __attribute__((fallthrough));
   case 5:
     pos[4] = w8[4];
+    __attribute__((fallthrough));
   case 4:
     pos[3] = w8[3];
+    __attribute__((fallthrough));
   case 3:
     pos[2] = w8[2];
+    __attribute__((fallthrough));
   case 2:
     pos[1] = w8[1];
+    __attribute__((fallthrough));
   case 1:
     pos[0] = w8[0];
+    __attribute__((fallthrough));
   }
   word.str[7] = len_mod;
 

--- a/lib/facil/core/types/fiobj/fiobject.c
+++ b/lib/facil/core/types/fiobj/fiobject.c
@@ -155,7 +155,7 @@ static inline int fiobj_iseq_simple(const FIOBJ o, const FIOBJ o2) {
     return 0; /* they should have compared equal before. */
   if (!FIOBJ_IS_ALLOCATED(o) || !FIOBJ_IS_ALLOCATED(o2))
     return 0; /* they should have compared equal before. */
-  if (FIOBJECT2HEAD(o)->type != FIOBJECT2HEAD(o)->type)
+  if (FIOBJECT2HEAD(o)->type != FIOBJECT2HEAD(o2)->type)
     return 0; /* non-type equality is a barriar to equality. */
   if (!FIOBJECT2VTBL(o)->is_eq(o, o2))
     return 0;

--- a/lib/facil/core/types/fiobj/fiobject.h
+++ b/lib/facil/core/types/fiobj/fiobject.h
@@ -575,7 +575,7 @@ FIO_INLINE int fiobj_iseq(const FIOBJ o, const FIOBJ o2) {
     return 0; /* they should have compared equal before. */
   if (!FIOBJ_IS_ALLOCATED(o) || !FIOBJ_IS_ALLOCATED(o2))
     return 0; /* they should have compared equal before. */
-  if (FIOBJECT2HEAD(o)->type != FIOBJECT2HEAD(o)->type)
+  if (FIOBJECT2HEAD(o)->type != FIOBJECT2HEAD(o2)->type)
     return 0; /* non-type equality is a barriar to equality. */
   if (!FIOBJECT2VTBL(o)->is_eq(o, o2))
     return 0;


### PR DESCRIPTION
Fixing a few warnings that I got during compilation.

I hope you don't mind the use of `__attribute__((fallthrough))`; I had a look in other parts of the code and you seem to be using other features like `__attribute__((unused))` so I figured it was ok to do so here in order to suppress the warnings.