### PR TITLE
Fix misdetect of GCC macro __has_builtin

### DIFF
--- a/lib/facil/fiobj/fiobject.h
+++ b/lib/facil/fiobj/fiobject.h
@@ -378,17 +378,11 @@ Atomic reference counting
   __atomic_sub_fetch(&FIOBJECT2HEAD(o)->ref, 1, __ATOMIC_SEQ_CST)
 
 /* Select the correct compiler builtin method. */
-#elif defined(__has_builtin)
-
-#if __has_builtin(__sync_fetch_and_or)
+#elif defined(__has_builtin) && __has_builtin(__sync_add_and_fetch)
 /** An atomic addition operation */
 #define fiobj_ref_inc(o) __sync_add_and_fetch(&FIOBJECT2HEAD(o)->ref, 1)
 /** An atomic subtraction operation */
 #define fiobj_ref_dec(o) __sync_sub_and_fetch(&FIOBJECT2HEAD(o)->ref, 1)
-
-#else
-#error missing required atomic options.
-#endif /* defined(__has_builtin) */
 
 #elif __GNUC__ > 3
 /** An atomic addition operation */

--- a/lib/facil/legacy/fio_mem.c
+++ b/lib/facil/legacy/fio_mem.c
@@ -166,18 +166,12 @@ typedef volatile unsigned char spn_lock_i;
 #define spn_sub(...) __atomic_sub_fetch(__VA_ARGS__, __ATOMIC_SEQ_CST)
 
 /* Select the correct compiler builtin method. */
-#elif defined(__has_builtin)
-
-#if __has_builtin(__sync_fetch_and_or)
+#elif defined(__has_builtin) &&  __has_builtin(__sync_fetch_and_or)
 #define SPN_LOCK_BUILTIN(...) __sync_fetch_and_or(__VA_ARGS__)
 /** An atomic addition operation */
 #define spn_add(...) __sync_add_and_fetch(__VA_ARGS__)
 /** An atomic subtraction operation */
 #define spn_sub(...) __sync_sub_and_fetch(__VA_ARGS__)
-
-#else
-#error Required builtin "__sync_swap" or "__sync_fetch_and_or" missing from compiler.
-#endif /* defined(__has_builtin) */
 
 #elif __GNUC__ > 3
 #define SPN_LOCK_BUILTIN(...) __sync_fetch_and_or(__VA_ARGS__)


### PR DESCRIPTION
There are some tests for a pre-defined macro `__has_builtin`, however this macro may has already defined from the code, to `0`, for example `lib/facil/fiobj/fiobject.h` line 38. This cause building with a GCC version that doesn't define `__has_builtin`, to fail.