### PR TITLE
Port to Solaris

### DIFF
--- a/lib/facil/fio.c
+++ b/lib/facil/fio.c
@@ -2313,11 +2313,11 @@ int fio_set_non_block(int fd) {
   if (-1 == (flags = fcntl(fd, F_GETFL, 0)))
     flags = 0;
   // printf("flags initial value was %d\n", flags);
-  return fcntl(fd, F_SETFL, flags | O_NONBLOCK
 #ifdef O_CLOEXEC
-                             | O_CLOEXEC
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK | O_CLOEXEC);
+#else
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 #endif
-    );
 #elif defined(FIONBIO)
   /* Otherwise, use the old way of doing it */
   static int flags = 1;

--- a/lib/facil/fio.c
+++ b/lib/facil/fio.c
@@ -2313,7 +2313,11 @@ int fio_set_non_block(int fd) {
   if (-1 == (flags = fcntl(fd, F_GETFL, 0)))
     flags = 0;
   // printf("flags initial value was %d\n", flags);
-  return fcntl(fd, F_SETFL, flags | O_NONBLOCK | O_CLOEXEC);
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK
+#ifdef O_CLOEXEC
+                             | O_CLOEXEC
+#endif
+    );
 #elif defined(FIONBIO)
   /* Otherwise, use the old way of doing it */
   static int flags = 1;
@@ -2710,7 +2714,7 @@ error:
 }
 
 #else
-static int (*fio_sock_sendfile_from_fd)(int fd, struct packet_s *packet) =
+static int (*fio_sock_sendfile_from_fd)(int fd, fio_packet_s *packet) =
     fio_sock_write_from_fd;
 
 #endif

--- a/lib/facil/fio.h
+++ b/lib/facil/fio.h
@@ -223,9 +223,16 @@ Version and helper macros
 #define __has_include(...) 0
 #define __has_builtin(...) 0
 #define FIO_GNUC_BYPASS 1
-#elif !defined(__clang__) && !defined(__has_builtin)
+#else
+#if defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 5))
+/* GCC < 4.5 doesn't support deprecation reason string */
+#define deprecated(reason) deprecated
+#endif
+#if !defined(__clang__) && !defined(__has_builtin)
+/* E.g: GCC < 6.0 doesn't support __has_builtin */
 #define __has_builtin(...) 0
 #define FIO_GNUC_BYPASS 1
+#endif
 #endif
 
 #ifndef FIO_FUNC

--- a/lib/facil/http/http.c
+++ b/lib/facil/http/http.c
@@ -18,6 +18,34 @@ Feel free to copy, use and enjoy according to the license provided.
 #include <sys/types.h>
 #include <unistd.h>
 
+#ifndef HAVE_TM_TM_ZONE
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+    defined(__DragonFly__) || defined(__bsdi__) || defined(__ultrix) ||	\
+    (defined(__APPLE__) && defined(__MACH__)) || \
+    (defined(__sun) && !defined(__SVR4))
+/* Known BSD systems */
+#define HAVE_TM_TM_ZONE 1
+#elif defined(__GLIBC__) && defined(_BSD_SOURCE)
+/* GNU systems with _BSD_SOURCE */
+#define HAVE_TM_TM_ZONE 1
+#else
+#define HAVE_TM_TM_ZONE 0
+#endif
+#endif
+
+#ifndef HAVE_TM_TM_GMTOFF
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+    defined(__DragonFly__) || defined(__bsdi__) || defined(__ultrix) ||	\
+    (defined(__APPLE__) && defined(__MACH__)) || \
+    (defined(__sun) && !defined(__SVR4))
+#define HAVE_TM_TM_GMTOFF 1
+#elif defined(__GLIBC__) && defined(_BSD_SOURCE)
+#define HAVE_TM_TM_GMTOFF 1
+#else
+#define HAVE_TM_TM_GMTOFF 0
+#endif
+#endif
+
 /* *****************************************************************************
 SSL/TLS patch
 ***************************************************************************** */
@@ -2073,10 +2101,10 @@ struct tm *http_gmtime(time_t timer, struct tm *tmbuf) {
   if (timer < 0)
     return gmtime_r(&timer, tmbuf);
   ssize_t a, b;
-#ifdef HAVE_TM_TM_GMTOFF
+#if HAVE_TM_TM_GMTOFF
   tmbuf->tm_gmtoff = 0;
 #endif
-#ifdef HAVE_TM_TM_ZONE
+#if HAVE_TM_TM_ZONE
   tmbuf->tm_zone = "UTC";
 #endif
   tmbuf->tm_isdst = 0;

--- a/lib/facil/http/http.c
+++ b/lib/facil/http/http.c
@@ -2073,8 +2073,12 @@ struct tm *http_gmtime(time_t timer, struct tm *tmbuf) {
   if (timer < 0)
     return gmtime_r(&timer, tmbuf);
   ssize_t a, b;
+#ifdef HAVE_TM_TM_GMTOFF
   tmbuf->tm_gmtoff = 0;
+#endif
+#ifdef HAVE_TM_TM_ZONE
   tmbuf->tm_zone = "UTC";
+#endif
   tmbuf->tm_isdst = 0;
   tmbuf->tm_year = 70; // tm_year == The number of years since 1900
   tmbuf->tm_mon = 0;

--- a/lib/facil/http/http.h
+++ b/lib/facil/http/http.h
@@ -7,14 +7,6 @@ Feel free to copy, use and enjoy according to the license provided.
 */
 #define H_HTTP_H
 
-#ifdef __GNUC__
-#if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 5)
-#define deprecated(reason) deprecated
-#endif
-#elif !defined(__clang__)
-#define __attribute__(...)
-#endif
-
 #include <fio.h>
 
 #include <fiobj.h>

--- a/lib/facil/http/http.h
+++ b/lib/facil/http/http.h
@@ -7,6 +7,12 @@ Feel free to copy, use and enjoy according to the license provided.
 */
 #define H_HTTP_H
 
+#ifdef __GNUC__
+#if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 5)
+#define deprecated(reason) deprecated
+#endif
+#endif
+
 #include <fio.h>
 
 #include <fiobj.h>

--- a/lib/facil/http/http.h
+++ b/lib/facil/http/http.h
@@ -11,6 +11,8 @@ Feel free to copy, use and enjoy according to the license provided.
 #if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 5)
 #define deprecated(reason) deprecated
 #endif
+#elif !defined(__clang__)
+#define __attribute__(...)
 #endif
 
 #include <fio.h>

--- a/makefile
+++ b/makefile
@@ -343,12 +343,12 @@ int main(void) {\\n\
 
 ifeq ($(call TRY_COMPILE, $(FIO_TEST_STRUCT_TM_TM_ZONE), $(EMPTY)), 0)
   $(info * Detected 'tm_zone' field in 'struct tm')
-	FLAGS:=$(FLAGS) HAVE_TM_TM_ZONE
+	FLAGS:=$(FLAGS) HAVE_TM_TM_ZONE=1
 endif
 
 ifeq ($(call TRY_COMPILE, $(FIO_TEST_STRUCT_TM_TM_GMTOFF), $(EMPTY)), 0)
   $(info * Detected 'tm_gmtoff' field in 'struct tm')
-	FLAGS:=$(FLAGS) HAVE_TM_TM_GMTOFF
+	FLAGS:=$(FLAGS) HAVE_TM_TM_GMTOFF=1
 endif
 
 #############################################################################


### PR DESCRIPTION
Add auto-detection of non-standard fields in `struct tm`;
Add auto-detection of SystemV socket libraries;
Compatibility fix for GCC older than version 4.5;
Fix a remaining type error in `sendfile` fallback function pointer.