### PR TITLE
Fix format warnings of type 'pid_t'

### DIFF
--- a/lib/facil/fio.c
+++ b/lib/facil/fio.c
@@ -3526,7 +3526,7 @@ static void __attribute__((destructor)) fio_lib_destroy(void) {
   fio_free(fio_data);
   /* memory library destruction must be last */
   fio_mem_destroy();
-  FIO_LOG_DEBUG("(%d) facil.io resources released, exit complete.", getpid());
+  FIO_LOG_DEBUG("(%d) facil.io resources released, exit complete.", (int)getpid());
   if (add_eol)
     fprintf(stderr, "\n"); /* add EOL to logs (logging adds EOL before text */
 }
@@ -3755,7 +3755,7 @@ static void fio_worker_startup(void) {
     fio_data->is_worker = 1;
   } else if (fio_data->is_worker) {
     /* Worker Process */
-    FIO_LOG_INFO("%d is running.", getpid());
+    FIO_LOG_INFO("%d is running.", (int)getpid());
   } else {
     /* Root Process should run in single thread mode */
     fio_data->threads = 1;
@@ -3779,7 +3779,7 @@ static void fio_worker_startup(void) {
 static void fio_worker_cleanup(void) {
   /* switch to winding down */
   if (fio_data->is_worker)
-    FIO_LOG_INFO("(%d) detected exit signal.", getpid());
+    FIO_LOG_INFO("(%d) detected exit signal.", (int)getpid());
   else
     FIO_LOG_INFO("Server Detected exit signal.");
   fio_state_callback_force(FIO_CALL_ON_SHUTDOWN);
@@ -3808,7 +3808,7 @@ static void fio_worker_cleanup(void) {
   if (fio_data->parent == getpid()) {
     FIO_LOG_INFO("   ---  Shutdown Complete  ---\n");
   } else {
-    FIO_LOG_INFO("(%d) cleanup complete.", getpid());
+    FIO_LOG_INFO("(%d) cleanup complete.", (int)getpid());
   }
 }
 
@@ -3842,11 +3842,11 @@ static void *fio_sentinel_worker_thread(void *arg) {
       /* don't call any functions while forking. */
       fio_lock(&fio_fork_lock);
       if (!WIFEXITED(status) || WEXITSTATUS(status)) {
-        FIO_LOG_ERROR("Child worker (%d) crashed. Respawning worker.", child);
+        FIO_LOG_ERROR("Child worker (%d) crashed. Respawning worker.", (int)child);
         fio_state_callback_force(FIO_CALL_ON_CHILD_CRUSH);
       } else {
         FIO_LOG_WARNING("Child worker (%d) shutdown. Respawning worker.",
-                        child);
+                        (int)child);
       }
       fio_defer_push_task(fio_sentinel_task, NULL, NULL);
       fio_unlock(&fio_fork_lock);
@@ -3910,7 +3910,7 @@ void fio_start FIO_IGNORE_MACRO(struct fio_start_args args) {
       "* Press ^C to stop\n",
       fio_data->workers, fio_data->workers > 1 ? "workers" : "worker",
       fio_data->threads, fio_data->threads > 1 ? "threads" : "thread",
-      fio_engine(), fio_data->capa, fio_data->parent);
+      fio_engine(), fio_data->capa, (int)fio_data->parent);
 
   if (args.workers > 1) {
     for (int i = 0; i < args.workers && fio_data->active; ++i) {
@@ -4489,9 +4489,9 @@ static void fio_listen_on_startup(void *pr_) {
   fio_listen_protocol_s *pr = pr_;
   fio_attach(pr->uuid, &pr->pr);
   if (pr->port_len)
-    FIO_LOG_DEBUG("(%d) started listening on port %s", getpid(), pr->port);
+    FIO_LOG_DEBUG("(%d) started listening on port %s", (int)getpid(), pr->port);
   else
-    FIO_LOG_DEBUG("(%d) started listening on Unix Socket at %s", getpid(),
+    FIO_LOG_DEBUG("(%d) started listening on Unix Socket at %s", (int)getpid(),
                   pr->addr);
 }
 
@@ -5830,7 +5830,7 @@ static struct cluster_data_s {
 static void fio_cluster_data_cleanup(int delete_file) {
   if (delete_file && cluster_data.name[0]) {
 #if DEBUG
-    FIO_LOG_DEBUG("(%d) unlinking cluster's Unix socket.", getpid());
+    FIO_LOG_DEBUG("(%d) unlinking cluster's Unix socket.", (int)getpid());
 #endif
     unlink(cluster_data.name);
   }
@@ -5879,7 +5879,7 @@ static void fio_cluster_init(void) {
   tmp_folder_len += 14;
   tmp_folder_len +=
       snprintf(cluster_data.name + tmp_folder_len,
-               FIO_CLUSTER_NAME_LIMIT - tmp_folder_len, "%d", getpid());
+               FIO_CLUSTER_NAME_LIMIT - tmp_folder_len, "%d", (int)getpid());
   cluster_data.name[tmp_folder_len] = 0;
 
   /* remove if existing */
@@ -5924,7 +5924,7 @@ static void fio_cluster_on_data(intptr_t uuid, fio_protocol_s *pr_) {
       if (c->exp_channel) {
         if (c->exp_channel >= (1024 * 1024 * 16) + 1) {
           FIO_LOG_FATAL("(%d) cluster message name too long (16Mb limit): %u\n",
-                        getpid(), (unsigned int)c->exp_channel);
+                        (int)getpid(), (unsigned int)c->exp_channel);
           exit(1);
           return;
         }
@@ -5932,7 +5932,7 @@ static void fio_cluster_on_data(intptr_t uuid, fio_protocol_s *pr_) {
       if (c->exp_msg) {
         if (c->exp_msg >= (1024 * 1024 * 64) + 1) {
           FIO_LOG_FATAL("(%d) cluster message data too long (64Mb limit): %u\n",
-                        getpid(), (unsigned int)c->exp_msg);
+                        (int)getpid(), (unsigned int)c->exp_msg);
           exit(1);
           return;
         }
@@ -6014,7 +6014,7 @@ static void fio_cluster_on_close(intptr_t uuid, fio_protocol_s *pr_) {
   } else if (fio_data->active) {
     /* no shutdown message received - parent crashed. */
     if (c->type != FIO_CLUSTER_MSG_SHUTDOWN && fio_is_running()) {
-      FIO_LOG_FATAL("(%d) Parent Process crash detected!", getpid());
+      FIO_LOG_FATAL("(%d) Parent Process crash detected!", (int)getpid());
       fio_state_callback_force(FIO_CALL_ON_PARENT_CRUSH);
       fio_state_callback_clear(FIO_CALL_ON_PARENT_CRUSH);
       fio_cluster_data_cleanup(1);
@@ -6177,7 +6177,7 @@ static void fio_cluster_listen_on_close(intptr_t uuid,
   cluster_data.uuid = -1;
   if (fio_parent_pid() == getpid()) {
 #if DEBUG
-    FIO_LOG_DEBUG("(%d) stopped listening for cluster connections", getpid());
+    FIO_LOG_DEBUG("(%d) stopped listening for cluster connections", (int)getpid());
 #endif
     if (fio_data->active)
       kill(0, SIGINT);
@@ -6203,7 +6203,7 @@ static void fio_listen2cluster(void *ignore) {
       .ping = mock_ping_eternal,
       .on_close = fio_cluster_listen_on_close,
   };
-  FIO_LOG_DEBUG("(%d) Listening to cluster: %s", getpid(), cluster_data.name);
+  FIO_LOG_DEBUG("(%d) Listening to cluster: %s", (int)getpid(), cluster_data.name);
   fio_attach(cluster_data.uuid, p);
   (void)ignore;
 }
@@ -6335,7 +6335,7 @@ static inline void fio_cluster_inform_root_about_channel(channel_s *ch,
   fio_str_info_s ch_name = {.data = ch->name, .len = ch->name_len};
   fio_str_info_s msg = {.data = NULL, .len = 0};
 #if DEBUG
-  FIO_LOG_DEBUG("(%d) informing root about: %s (%zu) msg type %d", getpid(),
+  FIO_LOG_DEBUG("(%d) informing root about: %s (%zu) msg type %d", (int)getpid(),
                 ch_name.data, ch_name.len,
                 (ch->match ? (add ? FIO_CLUSTER_MSG_PATTERN_SUB
                                   : FIO_CLUSTER_MSG_PATTERN_UNSUB)
@@ -9411,7 +9411,7 @@ FIO_FUNC void fio_socket_test(void) {
 #else
   fio_str_write(&sock_name, "/tmp", 4);
 #endif
-  fio_str_printf(&sock_name, "/fio_test_sock-%d.sock", getpid());
+  fio_str_printf(&sock_name, "/fio_test_sock-%d.sock", (int)getpid());
 
   fprintf(stderr, "=== Testing facil.io listening socket creation (partial "
                   "testing only).\n");

--- a/lib/facil/redis/redis_engine.c
+++ b/lib/facil/redis/redis_engine.c
@@ -320,7 +320,7 @@ static void redis_send_next_command_unsafe(redis_engine_s *r) {
         FIO_LS_EMBD_OBJ(redis_commands_s, node, r->queue.next);
     fio_write2(r->pub_data.uuid, .data.buffer = cmd->cmd,
                .length = cmd->cmd_len, .after.dealloc = FIO_DEALLOC_NOOP);
-    FIO_LOG_DEBUG("(redis %d) Sending (%zu bytes):\n%s\n", getpid(),
+    FIO_LOG_DEBUG("(redis %d) Sending (%zu bytes):\n%s\n", (int)getpid(),
                   cmd->cmd_len, cmd->cmd);
   }
 }
@@ -352,7 +352,7 @@ static void resp_on_pub_message(struct redis_engine_internal_s *i, FIOBJ msg) {
   if (!node) {
     /* TODO: possible ping? from server?! not likely... */
     FIO_LOG_WARNING("(redis %d) received a reply when no command was sent.",
-                    getpid());
+                    (int)getpid());
     return;
   }
   node->next = (void *)fiobj_dup(msg);
@@ -657,7 +657,7 @@ static void redis_on_publish_root(const fio_pubsub_engine_s *eng,
   *buf++ = '\r';
   *buf++ = '\n';
   *buf = 0;
-  FIO_LOG_DEBUG("(%d) Publishing:\n%s", getpid(), cmd->cmd);
+  FIO_LOG_DEBUG("(%d) Publishing:\n%s", (int)getpid(), cmd->cmd);
   cmd->cmd_len = (uintptr_t)buf - (uintptr_t)(cmd + 1);
   redis_attach_cmd(r, cmd);
   return;


### PR DESCRIPTION
Solaris has defined type `pid_t` as `long int` on 32-bit platforms, so using `%d` in a format string for `pid_t` will cause a compiler warning about the type mismatch.