### PR TITLE
Meson support with 'facial.io'...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/_site
 lib/bearssl/
 
 /src/
+build/
 
 .gitignore
 .DS_Store

--- a/lib/facil/http/parsers/http1_parser.c
+++ b/lib/facil/http/parsers/http1_parser.c
@@ -445,13 +445,13 @@ re_eval:
                                               : args->on_request)(args->parser))
       goto error;
     args->parser->state =
-        (struct http1_parser_protected_read_only_state_s){0, 0, 0};
+        (struct http1_parser_protected_read_only_state_s){0, 0, 0, 0};
   }
   return CONSUMED;
 error:
   args->on_error(args->parser);
   args->parser->state =
-      (struct http1_parser_protected_read_only_state_s){0, 0, 0};
+      (struct http1_parser_protected_read_only_state_s){0, 0, 0, 0};
   return args->length;
 }
 

--- a/lib/facil/meson.build
+++ b/lib/facil/meson.build
@@ -4,7 +4,7 @@
 #                                                                                 #
 # AUTHOR: Boaz Segev.                                                             #
 #                                                                                 #
-# WRITTEN BY: Michael Brockus.                                                     #
+# WRITTEN BY: Michael Brockus.                                                    #
 #                                                                                 #
 # CONTACT: <mailto:michael@squidfarts.com>                                        #
 #                                                                                 #

--- a/lib/facil/meson.build
+++ b/lib/facil/meson.build
@@ -1,0 +1,71 @@
+###################################################################################
+#                                                                                 #
+# NAME: meson.build                                                               #
+#                                                                                 #
+# AUTHOR: Michael Brockus.                                                        #
+#                                                                                 #
+# CONTACT: <mailto:michael@squidfarts.com>                                        #
+#                                                                                 #
+# NOTICES:                                                                        #
+#                                                                                 #
+# MIT License                                                                     #
+#                                                                                 #
+# Copyright (c) 2019 Team Squidfarts                                              #
+#                                                                                 #
+# Permission is hereby granted, free of charge, to any person obtaining a copy    #
+# of this software and associated documentation files (the "Software"), to deal   #
+# in the Software without restriction, including without limitation the rights    #
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell       #
+# copies of the Software, and to permit persons to whom the Software is           #
+# furnished to do so, subject to the following conditions:                        #
+#                                                                                 #
+# The above copyright notice and this permission notice shall be included in all  #
+# copies or substantial portions of the Software.                                 #
+#                                                                                 #
+# DISCLAIMERS:                                                                    #
+#                                                                                 #
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   #
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   #
+# SOFTWARE.                                                                       #
+#                                                                                 #
+###################################################################################
+
+
+
+facil_src = files(
+    [
+        join_paths('fio.c'),
+        join_paths('tls', 'fio_tls_missing.c'),
+        join_paths('tls', 'fio_tls_openssl.c'),
+        join_paths('fiobj', 'fio_siphash.c'),
+        join_paths('fiobj', 'fiobj_ary.c'),
+        join_paths('fiobj', 'fiobj_data.c'),
+        join_paths('fiobj', 'fiobj_hash.c'),
+        join_paths('fiobj', 'fiobj_json.c'),
+        join_paths('fiobj', 'fiobj_mustache.c'),
+        join_paths('fiobj', 'fiobj_numbers.c'),
+        join_paths('fiobj', 'fiobj_str.c'),
+        join_paths('fiobj', 'fiobject.c'),
+        join_paths('cli', 'fio_cli.c'),
+        join_paths('http', 'http.c'),
+        join_paths('http', 'http1.c'),
+        join_paths('http', 'http_internal.c'),
+        join_paths('http', 'websockets.c'),
+        join_paths('http', 'parsers', 'http1_parser.c'),
+        join_paths( 'redis', 'redis_engine.c'),
+    ])
+
+facil_dir = include_directories(
+    [
+        '.', 
+        'tls', 
+        'fiobj', 
+        'cli', 
+        'http', 
+        'redis',
+        join_paths('http', 'parsers')
+    ])

--- a/lib/facil/meson.build
+++ b/lib/facil/meson.build
@@ -2,7 +2,9 @@
 #                                                                                 #
 # NAME: meson.build                                                               #
 #                                                                                 #
-# AUTHOR: Michael Brockus.                                                        #
+# AUTHOR: Boaz Segev.                                                             #
+#                                                                                 #
+# WRITTEN BY: Michael Brockus.                                                     #
 #                                                                                 #
 # CONTACT: <mailto:michael@squidfarts.com>                                        #
 #                                                                                 #

--- a/lib/facil/meson.build
+++ b/lib/facil/meson.build
@@ -12,7 +12,7 @@
 #                                                                                 #
 # MIT License                                                                     #
 #                                                                                 #
-# Copyright (c) 2019 Team Squidfarts                                              #
+# Copyright (c) Boaz Segev, 2018-2019                                             #
 #                                                                                 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy    #
 # of this software and associated documentation files (the "Software"), to deal   #

--- a/lib/facil/meson.build
+++ b/lib/facil/meson.build
@@ -1,38 +1,12 @@
 ###################################################################################
 #                                                                                 #
-# NAME: meson.build                                                               #
+# NAME: lib/facil/meson.build                                                     #
 #                                                                                 #
 # AUTHOR: Boaz Segev.                                                             #
 #                                                                                 #
 # WRITTEN BY: Michael Brockus.                                                    #
 #                                                                                 #
-# CONTACT: <mailto:michael@squidfarts.com>                                        #
-#                                                                                 #
-# NOTICES:                                                                        #
-#                                                                                 #
-# MIT License                                                                     #
-#                                                                                 #
-# Copyright (c) Boaz Segev, 2018-2019                                             #
-#                                                                                 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy    #
-# of this software and associated documentation files (the "Software"), to deal   #
-# in the Software without restriction, including without limitation the rights    #
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell       #
-# copies of the Software, and to permit persons to whom the Software is           #
-# furnished to do so, subject to the following conditions:                        #
-#                                                                                 #
-# The above copyright notice and this permission notice shall be included in all  #
-# copies or substantial portions of the Software.                                 #
-#                                                                                 #
-# DISCLAIMERS:                                                                    #
-#                                                                                 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      #
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     #
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          #
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   #
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   #
-# SOFTWARE.                                                                       #
+# License: MIT                                                                    #
 #                                                                                 #
 ###################################################################################
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -13,3 +13,9 @@
 
 
 subdir('facil')
+
+facil_lib = library(meson.project_name(), 
+    sources: facil_src,
+    include_directories: facil_dir,
+    dependencies: [ threads_dep, m_dep ],
+    install: true)

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,38 +1,12 @@
 ###################################################################################
 #                                                                                 #
-# NAME: meson.build                                                               #
+# NAME: lib/meson.build                                                           #
 #                                                                                 #
 # AUTHOR: Boaz Segev.                                                             #
 #                                                                                 #
-# WRITTEN BY: Michael Brockus.                                                     #
+# WRITTEN BY: Michael Brockus.                                                    #
 #                                                                                 #
-# CONTACT: <mailto:michael@squidfarts.com>                                        #
-#                                                                                 #
-# NOTICES:                                                                        #
-#                                                                                 #
-# MIT License                                                                     #
-#                                                                                 #
-# Copyright (c) 2019 Team Squidfarts                                              #
-#                                                                                 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy    #
-# of this software and associated documentation files (the "Software"), to deal   #
-# in the Software without restriction, including without limitation the rights    #
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell       #
-# copies of the Software, and to permit persons to whom the Software is           #
-# furnished to do so, subject to the following conditions:                        #
-#                                                                                 #
-# The above copyright notice and this permission notice shall be included in all  #
-# copies or substantial portions of the Software.                                 #
-#                                                                                 #
-# DISCLAIMERS:                                                                    #
-#                                                                                 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      #
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     #
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          #
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   #
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   #
-# SOFTWARE.                                                                       #
+# License: MIT                                                                    #
 #                                                                                 #
 ###################################################################################
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -2,7 +2,9 @@
 #                                                                                 #
 # NAME: meson.build                                                               #
 #                                                                                 #
-# AUTHOR: Michael Brockus.                                                        #
+# AUTHOR: Boaz Segev.                                                             #
+#                                                                                 #
+# WRITTEN BY: Michael Brockus.                                                     #
 #                                                                                 #
 # CONTACT: <mailto:michael@squidfarts.com>                                        #
 #                                                                                 #

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,0 +1,39 @@
+###################################################################################
+#                                                                                 #
+# NAME: meson.build                                                               #
+#                                                                                 #
+# AUTHOR: Michael Brockus.                                                        #
+#                                                                                 #
+# CONTACT: <mailto:michael@squidfarts.com>                                        #
+#                                                                                 #
+# NOTICES:                                                                        #
+#                                                                                 #
+# MIT License                                                                     #
+#                                                                                 #
+# Copyright (c) 2019 Team Squidfarts                                              #
+#                                                                                 #
+# Permission is hereby granted, free of charge, to any person obtaining a copy    #
+# of this software and associated documentation files (the "Software"), to deal   #
+# in the Software without restriction, including without limitation the rights    #
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell       #
+# copies of the Software, and to permit persons to whom the Software is           #
+# furnished to do so, subject to the following conditions:                        #
+#                                                                                 #
+# The above copyright notice and this permission notice shall be included in all  #
+# copies or substantial portions of the Software.                                 #
+#                                                                                 #
+# DISCLAIMERS:                                                                    #
+#                                                                                 #
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   #
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   #
+# SOFTWARE.                                                                       #
+#                                                                                 #
+###################################################################################
+
+
+
+subdir('facil')

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,6 @@
 
 
 project('facil.io', 'c',
-    version         : '0.7.2',
     license         : 'MIT',
     meson_version   : '>=0.50.0',
     default_options : 
@@ -46,7 +45,6 @@ facil_lib = library(meson.project_name(),
 
 
 facil_dep = declare_dependency(
-    link_with: facil_lib, 
-    version: meson.project_version(),
+    link_with: facil_lib,
     include_directories: facil_dir,
     dependencies: [ threads_dep, m_dep ])

--- a/meson.build
+++ b/meson.build
@@ -60,19 +60,8 @@ args_for_langs = 'c'
 threads_dep = dependency('threads')
 m_dep = cc.find_library('m', required : false)
 
-subdir('lib')
 
-facil_dir = include_directories(
-    [
-        join_paths('lib'),
-        join_paths('lib', 'facil'),
-        join_paths('lib', 'facil', 'tls'),
-        join_paths('lib', 'facil', 'fiobj'),
-        join_paths('lib', 'facil', 'cli'),
-        join_paths('lib', 'facil', 'http'),
-        join_paths('lib', 'facil', 'http', 'parsers'),
-        join_paths('lib', 'facil', 'redis')
-    ])
+subdir('lib')
 
 
 facil_lib = library(meson.project_name(), 

--- a/meson.build
+++ b/meson.build
@@ -42,12 +42,12 @@ project('facil.io', 'c',
     meson_version   : '>=0.50.0',
     default_options : 
     [ 
+        'werror=true',
         'optimization=3', 
         'warning_level=3', 
         'b_sanitize=undefined', 
         'b_lto=true', 
-        'b_lundef=true', 
-        'c_std=c17' 
+        'b_lundef=true' 
     ]
 )
 cc = meson.get_compiler('c')
@@ -58,29 +58,7 @@ args_for_langs = 'c'
 threads_dep = dependency('threads')
 m_dep = cc.find_library('m', required : false)
 
-
-facil_src = files(
-    [
-        join_paths('lib', 'facil', 'fio.c'),
-        join_paths('lib', 'facil', 'tls', 'fio_tls_missing.c'),
-        join_paths('lib', 'facil', 'tls', 'fio_tls_openssl.c'),
-        join_paths('lib', 'facil', 'fiobj', 'fio_siphash.c'),
-        join_paths('lib', 'facil', 'fiobj', 'fiobj_ary.c'),
-        join_paths('lib', 'facil', 'fiobj', 'fiobj_data.c'),
-        join_paths('lib', 'facil', 'fiobj', 'fiobj_hash.c'),
-        join_paths('lib', 'facil', 'fiobj', 'fiobj_json.c'),
-        join_paths('lib', 'facil', 'fiobj', 'fiobj_mustache.c'),
-        join_paths('lib', 'facil', 'fiobj', 'fiobj_numbers.c'),
-        join_paths('lib', 'facil', 'fiobj', 'fiobj_str.c'),
-        join_paths('lib', 'facil', 'fiobj', 'fiobject.c'),
-        join_paths('lib', 'facil', 'cli', 'fio_cli.c'),
-        join_paths('lib', 'facil', 'http', 'http.c'),
-        join_paths('lib', 'facil', 'http', 'http1.c'),
-        join_paths('lib', 'facil', 'http', 'http_internal.c'),
-        join_paths('lib', 'facil', 'http', 'websockets.c'),
-        join_paths('lib', 'facil', 'http', 'parsers', 'http1_parser.c'),
-        join_paths('lib', 'facil', 'redis', 'redis_engine.c'),
-    ])
+subdir('lib')
 
 facil_dir = include_directories(
     [

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,108 @@
+###################################################################################
+#                                                                                 #
+# NAME: meson.build                                                               #
+#                                                                                 #
+# AUTHOR: Michael Brockus.                                                        #
+#                                                                                 #
+# CONTACT: <mailto:michael@squidfarts.com>                                        #
+#                                                                                 #
+# NOTICES:                                                                        #
+#                                                                                 #
+# MIT License                                                                     #
+#                                                                                 #
+# Copyright (c) 2019 Team Squidfarts                                              #
+#                                                                                 #
+# Permission is hereby granted, free of charge, to any person obtaining a copy    #
+# of this software and associated documentation files (the "Software"), to deal   #
+# in the Software without restriction, including without limitation the rights    #
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell       #
+# copies of the Software, and to permit persons to whom the Software is           #
+# furnished to do so, subject to the following conditions:                        #
+#                                                                                 #
+# The above copyright notice and this permission notice shall be included in all  #
+# copies or substantial portions of the Software.                                 #
+#                                                                                 #
+# DISCLAIMERS:                                                                    #
+#                                                                                 #
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   #
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   #
+# SOFTWARE.                                                                       #
+#                                                                                 #
+###################################################################################
+
+
+
+project('facil.io', 'c',
+    version         : '0.2.4',
+    license         : 'MIT',
+    meson_version   : '>=0.50.0',
+    default_options : 
+    [ 
+        'optimization=3', 
+        'warning_level=3', 
+        'b_sanitize=undefined', 
+        'b_lto=true', 
+        'b_lundef=true', 
+        'c_std=c17' 
+    ]
+)
+cc = meson.get_compiler('c')
+args_for_langs = 'c'
+
+
+
+threads_dep = dependency('threads')
+m_dep = cc.find_library('m', required : false)
+
+
+facil_src = files(
+    [
+        join_paths('lib', 'facil', 'fio.c'),
+        join_paths('lib', 'facil', 'tls', 'fio_tls_missing.c'),
+        join_paths('lib', 'facil', 'tls', 'fio_tls_openssl.c'),
+        join_paths('lib', 'facil', 'fiobj', 'fio_siphash.c'),
+        join_paths('lib', 'facil', 'fiobj', 'fiobj_ary.c'),
+        join_paths('lib', 'facil', 'fiobj', 'fiobj_data.c'),
+        join_paths('lib', 'facil', 'fiobj', 'fiobj_hash.c'),
+        join_paths('lib', 'facil', 'fiobj', 'fiobj_json.c'),
+        join_paths('lib', 'facil', 'fiobj', 'fiobj_mustache.c'),
+        join_paths('lib', 'facil', 'fiobj', 'fiobj_numbers.c'),
+        join_paths('lib', 'facil', 'fiobj', 'fiobj_str.c'),
+        join_paths('lib', 'facil', 'fiobj', 'fiobject.c'),
+        join_paths('lib', 'facil', 'cli', 'fio_cli.c'),
+        join_paths('lib', 'facil', 'http', 'http.c'),
+        join_paths('lib', 'facil', 'http', 'http1.c'),
+        join_paths('lib', 'facil', 'http', 'http_internal.c'),
+        join_paths('lib', 'facil', 'http', 'websockets.c'),
+        join_paths('lib', 'facil', 'http', 'parsers', 'http1_parser.c'),
+        join_paths('lib', 'facil', 'redis', 'redis_engine.c'),
+    ])
+
+facil_dir = include_directories(
+    [
+        join_paths('lib'),
+        join_paths('lib', 'facil'),
+        join_paths('lib', 'facil', 'tls'),
+        join_paths('lib', 'facil', 'fiobj'),
+        join_paths('lib', 'facil', 'cli'),
+        join_paths('lib', 'facil', 'http'),
+        join_paths('lib', 'facil', 'http', 'parsers'),
+        join_paths('lib', 'facil', 'redis')
+    ])
+
+
+facil_lib = library(meson.project_name(), 
+    sources: facil_src,
+    include_directories: facil_dir,
+    dependencies: [ threads_dep, m_dep ],
+    install: true)
+
+
+facil_dep = declare_dependency(
+    link_with: facil_lib, 
+    include_directories: facil_dir,
+    dependencies: [ threads_dep, m_dep ])

--- a/meson.build
+++ b/meson.build
@@ -4,35 +4,9 @@
 #                                                                                 #
 # AUTHOR: Boaz Segev.                                                             #
 #                                                                                 #
-# WRITTEN BY: Michael Brockus.                                                     #
+# WRITTEN BY: Michael Brockus.                                                    #
 #                                                                                 #
-# CONTACT: <mailto:michael@squidfarts.com>                                        #
-#                                                                                 #
-# NOTICES:                                                                        #
-#                                                                                 #
-# MIT License                                                                     #
-#                                                                                 #
-# Copyright (c) Boaz Segev, 2018-2019                                             #
-#                                                                                 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy    #
-# of this software and associated documentation files (the "Software"), to deal   #
-# in the Software without restriction, including without limitation the rights    #
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell       #
-# copies of the Software, and to permit persons to whom the Software is           #
-# furnished to do so, subject to the following conditions:                        #
-#                                                                                 #
-# The above copyright notice and this permission notice shall be included in all  #
-# copies or substantial portions of the Software.                                 #
-#                                                                                 #
-# DISCLAIMERS:                                                                    #
-#                                                                                 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      #
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        #
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     #
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          #
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   #
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   #
-# SOFTWARE.                                                                       #
+# License: MIT                                                                    #
 #                                                                                 #
 ###################################################################################
 

--- a/meson.build
+++ b/meson.build
@@ -73,5 +73,6 @@ facil_lib = library(meson.project_name(),
 
 facil_dep = declare_dependency(
     link_with: facil_lib, 
+    version: meson.project_version(),
     include_directories: facil_dir,
     dependencies: [ threads_dep, m_dep ])

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@
 #                                                                                 #
 # MIT License                                                                     #
 #                                                                                 #
-# Copyright (c) 2019 Team Squidfarts                                              #
+# Copyright (c) Boaz Segev, 2018-2019                                             #
 #                                                                                 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy    #
 # of this software and associated documentation files (the "Software"), to deal   #

--- a/meson.build
+++ b/meson.build
@@ -41,14 +41,6 @@ m_dep = cc.find_library('m', required : false)
 
 subdir('lib')
 
-
-facil_lib = library(meson.project_name(), 
-    sources: facil_src,
-    include_directories: facil_dir,
-    dependencies: [ threads_dep, m_dep ],
-    install: true)
-
-
 facil_dep = declare_dependency(
     link_with: facil_lib,
     include_directories: facil_dir,

--- a/meson.build
+++ b/meson.build
@@ -29,10 +29,15 @@ cc = meson.get_compiler('c')
 args_for_langs = 'c'
 
 
+openssl = dependency('openssl', required: cc.get_id() != 'msvc')
 
+if not openssl.found()
+        libcrypto = cc.find_library('libcrypto', required: false)
+        libssl = cc.find_library('libssl')
+        openssl = [libcrypto, libssl]
+endif
 threads_dep = dependency('threads')
 m_dep = cc.find_library('m', required : false)
-
 
 subdir('lib')
 

--- a/meson.build
+++ b/meson.build
@@ -37,13 +37,13 @@
 
 
 project('facil.io', 'c',
-    version         : '0.2.4',
+    version         : '0.7.2',
     license         : 'MIT',
     meson_version   : '>=0.50.0',
     default_options : 
     [ 
         'werror=true',
-        'optimization=3', 
+        'optimization=2', 
         'warning_level=3', 
         'b_sanitize=undefined', 
         'b_lto=true', 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,9 @@
 #                                                                                 #
 # NAME: meson.build                                                               #
 #                                                                                 #
-# AUTHOR: Michael Brockus.                                                        #
+# AUTHOR: Boaz Segev.                                                             #
+#                                                                                 #
+# WRITEN BY: Michael Brockus.                                                     #
 #                                                                                 #
 # CONTACT: <mailto:michael@squidfarts.com>                                        #
 #                                                                                 #

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 #                                                                                 #
 # AUTHOR: Boaz Segev.                                                             #
 #                                                                                 #
-# WRITEN BY: Michael Brockus.                                                     #
+# WRITTEN BY: Michael Brockus.                                                     #
 #                                                                                 #
 # CONTACT: <mailto:michael@squidfarts.com>                                        #
 #                                                                                 #


### PR DESCRIPTION
I wrote a meson.build and some sub meson.build scripts to better modularize the Meson code and to avoid longe path variables when trying to find header files in the directory include paths.  This is currently a working progress 

Meson can dedicated libraries on the users system [here](https://mesonbuild.com/Dependencies.html).  There is also this wrap file tool for third party dependencies [here](https://mesonbuild.com/Wrap-dependency-system-manual.html).


Command line results:

`
Last login: Wed Jun 26 20:02:51 on ttys000
Michaels-MacBook-Pro:~ shnitzel$ cd Developer/github/fork/facil.io/
Michaels-MacBook-Pro:facil.io shnitzel$ meson setup build
The Meson build system
Version: 0.51.999
Source dir: /Users/shnitzel/Developer/github/fork/facil.io
Build dir: /Users/shnitzel/Developer/github/fork/facil.io/build
Build type: native build
Project name: facil.io
Project version: 0.2.4
C compiler for the build machine: cc (clang 10.0.1 "Apple LLVM version 10.0.1 (clang-1001.0.46.4)")
C compiler for the host machine: cc (clang 10.0.1 "Apple LLVM version 10.0.1 (clang-1001.0.46.4)")
Build machine cpu family: x86_64
Build machine cpu: x86_64
Run-time dependency threads found: YES 
Library m found: YES
Build targets in project: 1
Found ninja-1.9.0.git at /opt/local/bin/ninja
Michaels-MacBook-Pro:facil.io shnitzel$ ninja -C build/
ninja: Entering directory `build/'
[20/20] Linking static target libfacil.io.a.
Michaels-MacBook-Pro:facil.io shnitzel$ 
`


PS I think I may have fixed a bug in 'http1_parser.c' this error was printing to the consul until I made a fix.  Also I tried to add compiler flags and more errors printed so there is going to be a lot work to do.

`
Michaels-MacBook-Pro:facil.io shnitzel$ ninja -C build/
ninja: Entering directory `build/'
[13/20] Compiling C object 'facil.io@s..._facil_http_parsers_http1_parser.c.o'.
FAILED: facil.io@sha/lib_facil_http_parsers_http1_parser.c.o 
cc -Ifacil.io@sha -I. -I.. -Ilib -I../lib -Ilib/facil -I../lib/facil -I../lib/facil/tls -I../lib/facil/fiobj -I../lib/facil/cli -I../lib/facil/http -I../lib/facil/http/parsers -I../lib/facil/redis -flto -Xclang -fcolor-diagnostics -fsanitize=undefined -pipe -Wall -Winvalid-pch -Wextra -Wpedantic -Werror -O3 -g -MD -MQ 'facil.io@sha/lib_facil_http_parsers_http1_parser.c.o' -MF 'facil.io@sha/lib_facil_http_parsers_http1_parser.c.o.d' -o 'facil.io@sha/lib_facil_http_parsers_http1_parser.c.o' -c ../lib/facil/http/parsers/http1_parser.c
../lib/facil/http/parsers/http1_parser.c:448:66: error: missing field 'reserved' initializer [-Werror,-Wmissing-field-initializers]
        (struct http1_parser_protected_read_only_state_s){0, 0, 0};
                                                                 ^
../lib/facil/http/parsers/http1_parser.c:454:64: error: missing field 'reserved' initializer [-Werror,-Wmissing-field-initializers]
      (struct http1_parser_protected_read_only_state_s){0, 0, 0};
                                                               ^
2 errors generated.
[18/20] Compiling C object 'facil.io@sha/lib_facil_fio.c.o'.
ninja: build stopped: subcommand failed.
`
