### PR TITLE
Fix memory leak `tls->trust` + various linking-related fixes

### DIFF
--- a/lib/facil/tls/fio_tls_missing.c
+++ b/lib/facil/tls/fio_tls_missing.c
@@ -19,7 +19,7 @@ Feel free to copy, use and enjoy according to the license provided.
  */
 #include "fio_tls.h"
 
-#if 1 /* TODO: place library compiler flags here */
+#if !defined(HAVE_TLS) /* Library compiler flags */
 
 #define REQUIRE_LIBRARY()
 #define FIO_TLS_WEAK

--- a/lib/facil/tls/fio_tls_missing.c
+++ b/lib/facil/tls/fio_tls_missing.c
@@ -19,7 +19,7 @@ Feel free to copy, use and enjoy according to the license provided.
  */
 #include "fio_tls.h"
 
-#if !defined(HAVE_TLS) /* Library compiler flags */
+#if !defined(FIO_TLS_FOUND) /* Library compiler flags */
 
 #define REQUIRE_LIBRARY()
 #define FIO_TLS_WEAK

--- a/lib/facil/tls/fio_tls_openssl.c
+++ b/lib/facil/tls/fio_tls_openssl.c
@@ -1005,6 +1005,7 @@ void FIO_TLS_WEAK fio_tls_destroy(fio_tls_s *tls) {
   fio_tls_destroy_context(tls);
   alpn_list_free(&tls->alpn);
   cert_ary_free(&tls->sni);
+  trust_ary_free(&tls->trust);
   free(tls);
 }
 

--- a/makefile
+++ b/makefile
@@ -524,8 +524,10 @@ build_objects: $(LIB_OBJS) $(MAIN_OBJS)
 
 lib: | create_tree lib_build
 
-lib_build: $(LIB_OBJS)
-	@$(CCL) -shared -o $(DEST)/libfacil.so $^ $(OPTIMIZATION) $(LINKER_FLAGS)
+$(DEST)/libfacil.so: $(LIB_OBJS)
+	@$(CCL) -shared -o $@ $^ $(OPTIMIZATION) $(LINKER_FLAGS)
+
+lib_build: $(DEST)/libfacil.so
 	@$(DOCUMENTATION)
 
 

--- a/makefile
+++ b/makefile
@@ -425,7 +425,7 @@ else ifeq ($(call TRY_COMPILE, $(FIO_TLS_TEST_BEARSSL_EXT), "-lbearssl"), 0)
 	LINKER_LIBS_EXT:=$(LINKER_LIBS_EXT) bearssl
 else ifeq ($(call TRY_COMPILE, $(FIO_TLS_TEST_OPENSSL), "-lcrypto" "-lssl"), 0)
   $(info * Detected the OpenSSL library, setting HAVE_OPENSSL)
-	FLAGS:=$(FLAGS) HAVE_OPENSSL
+	FLAGS:=$(FLAGS) HAVE_OPENSSL HAVE_TLS
 	LINKER_LIBS_EXT:=$(LINKER_LIBS_EXT) crypto ssl
 else
   $(info * No compatible SSL/TLS library detected.)

--- a/makefile
+++ b/makefile
@@ -149,6 +149,12 @@ else
 	DOCUMENTATION=
 endif
 
+# GCC (at least) >= 7 triggers some bug when -fipa-icf is enabled
+# (as in our default: -O2)
+ifeq ($(shell $(CC) -v 2>&1 | grep -o "^gcc version"),gcc version)
+	OPTIMIZATION += -fno-ipa-icf
+endif
+
 #############################################################################
 # Automatic Setting Expansion
 # (don't edit)

--- a/makefile
+++ b/makefile
@@ -141,6 +141,7 @@ ifeq ($(OS),Darwin) # Run MacOS commands
 	# DISAMS=otool -dtVGX
 	# documentation commands
 	# DOCUMENTATION=cldoc generate $(INCLUDE_STR) -- --output ./html $(foreach dir, $(LIB_PUBLIC_SUBFOLDERS), $(wildcard $(addsuffix /, $(basename $(dir)))*.h*))
+$(DEST)/libfacil.so: LDFLAGS += -dynamiclib -install_name $(realpath $(DEST))/libfacil.so
 else
 	# debugger
 	DB=gdb

--- a/makefile
+++ b/makefile
@@ -435,14 +435,16 @@ OPENSSL_LDFLAGS ?= "-lssl" "-lcrypto"
 ifdef FIO_NO_TLS
 else ifeq ($(call TRY_COMPILE, $(FIO_TLS_TEST_BEARSSL_SOURCE), $(EMPTY)), 0)
   $(info * Detected the BearSSL source code library, setting HAVE_BEARSSL)
+	# TODO: when BearSSL support arrived, set the FIO_TLS_FOUND flag as well
 	FLAGS:=$(FLAGS) HAVE_BEARSSL
 else ifeq ($(call TRY_COMPILE, $(FIO_TLS_TEST_BEARSSL_EXT), "-lbearssl"), 0)
   $(info * Detected the BearSSL library, setting HAVE_BEARSSL)
+	# TODO: when BearSSL support arrived, set the FIO_TLS_FOUND flag as well
 	FLAGS:=$(FLAGS) HAVE_BEARSSL
 	LINKER_LIBS_EXT:=$(LINKER_LIBS_EXT) bearssl
 else ifeq ($(call TRY_COMPILE, $(FIO_TLS_TEST_OPENSSL), $(OPENSSL_CFLAGS) $(OPENSSL_LDFLAGS)), 0)
   $(info * Detected the OpenSSL library, setting HAVE_OPENSSL)
-	FLAGS:=$(FLAGS) HAVE_OPENSSL HAVE_TLS
+	FLAGS:=$(FLAGS) HAVE_OPENSSL FIO_TLS_FOUND
 	LINKER_LIBS_EXT:=$(LINKER_LIBS_EXT) $(OPENSSL_LIBS)
 	LDFLAGS += $(OPENSSL_LDFLAGS)
 	CFLAGS += $(OPENSSL_CFLAGS)
@@ -455,6 +457,7 @@ endif
 # S2N TLS/SSL library: https://github.com/awslabs/s2n
 ifeq ($(call TRY_COMPILE, "\#include <s2n.h>\\n int main(void) {}", "-ls2n") , 0)
   $(info * Detected the s2n library, setting HAVE_S2N)
+	# TODO: when S2N support arrived, set the FIO_TLS_FOUND flag as well
 	FLAGS:=$(FLAGS) HAVE_S2N
 	LINKER_LIBS_EXT:=$(LINKER_LIBS_EXT) s2n
 endif

--- a/makefile
+++ b/makefile
@@ -423,7 +423,7 @@ int main(void) { \\n\
 # automatic library adjustments for possible BearSSL library
 LIB_PRIVATE_SUBFOLDERS:=$(LIB_PRIVATE_SUBFOLDERS) $(if $(wildcard lib/bearssl),bearssl)
 
-ifeq ($(shell $(PKG_CONFIG) -- openssl 2>&1 >/dev/null; echo $$?), 0)
+ifeq ($(shell $(PKG_CONFIG) -- openssl >/dev/null 2>&1; echo $$?), 0)
 	OPENSSL_CFLAGS = $(shell $(PKG_CONFIG) --cflags openssl)
 	OPENSSL_LDFLAGS = $(shell $(PKG_CONFIG) --libs openssl)
 	OPENSSL_LIBS =


### PR DESCRIPTION
Hi,

I'm very happy that you put so much effort into this library, I found it easy to use for a Websocket client application I'm building which should run on Linux and Mac OS X, thank you!

However, I encountered a few things I needed to change:
- https://github.com/boazsegev/facil.io/commit/fcde3f074ba1b35d3b69ebb5270b52686fe26d4e fixes the memory leak when `tls->trust` is not cleaned up in `fio_tls_destroy(tls)`
- Building an OpenSSL-enabled facil.io on Mac OS X confuses the dynamic loader, because `fio_tls_missing.c` is built into the library defining the same symbols as `fio_tls_openssl.c` does, so in https://github.com/boazsegev/facil.io/commit/21614c0876769bbb83a4e46f65123e586171543e I renamed the file to `fio_tls_missing.sample-c` s.t. it is not built into the library anymore
- The other changes concern the `makefile`:
  - On OS X I installed OpenSSL-1.1 via [MacPorts](https://www.macports.org/), however facil.io's `makefile` didn't find it (it assumed standard empty compiler and linker flags whereas MacPorts installed into `/opt/local`). Thus, https://github.com/boazsegev/facil.io/commit/56fece97cefffe82561e17a2e43ab27bbe7ad726 uses `pkg-config` to determine the flags necessary to link against OpenSSL, which fixes that issue for me.
  - On Linux when building facil.io with GCC (v7.3.0, v8.3.0, v9.1.0, v9.2.0) and the default optimization `-O2` from the `makefile`, I encountered a strange bug where `http_upgrade2ws()` would silently return a negative value and not continue to upgrade the connection. I cannot be more precise at this point, would have to investigate. The issue does not occur with `clang-7` or `clang-8`. However, I tracked the bug to the `-fipa-icf` option of GCC (`-O1 -fipa-icf` already causes the buggy behaviour), therefore https://github.com/boazsegev/facil.io/commit/63745209efb7ea03fe18b7959a236e671e28c369 passes `-fno-ipa-icf` to the default `OPTIMIZATION` variable in the `makefile`.
  - https://github.com/boazsegev/facil.io/pull/71/commits/01edc0a3b697249b6eb6ca83af76e2e4c639ece4 is a small optimization of the `makefile` I made because (locally, not in this PR) I also wanted to build a static `libfacil.a` archive.
  - Linking against `libfacil.so` on OS X requires an `-install_name` to be set in the object file for OS X's dynamic loader to find the absolute path to the library when loading the program linking to it. https://github.com/boazsegev/facil.io/pull/71/commits/775e22202ccf5afb3d4807ce27303f7e8882719c adds the OS X specific linking options on Darwin.
  - Finally, since `pkg-config` worked quite well and the project I'm developing already relies on it for other libraries, https://github.com/boazsegev/facil.io/pull/71/commits/aa4c01c31ce0051814741f0ab30a5ecc6fb8758e makes the `makefile` learn how to write a `pkgconfig/facil.pc` file by itself, which makes linking to `libfacil.so` much easier for me.

I realize, you are developing v0.8 now, still I hope you find these patches useful. If you want to any changes made to them, please let me know.