### PR TITLE
Bugfix compiling C++

### DIFF
--- a/lib/facil/fio.h
+++ b/lib/facil/fio.h
@@ -1250,7 +1250,7 @@ inline FIO_FUNC ssize_t fio_write(const intptr_t uuid, const void *buffer,
 inline FIO_FUNC ssize_t fio_sendfile(intptr_t uuid, intptr_t source_fd,
                                      off_t offset, size_t length) {
   return fio_write2(uuid, .data.fd = source_fd, .length = length, .is_fd = 1,
-                    .offset = (unsigned long)offset);
+                    .offset = (uintptr_t)offset);
 }
 
 /**
@@ -2985,7 +2985,7 @@ FIO_FUNC inline void fio_reschedule_thread(void) {
 /** Nanosleep the thread - a blocking throttle. */
 FIO_FUNC inline void fio_throttle_thread(size_t nano_sec) {
   const struct timespec tm = {.tv_nsec = (long)(nano_sec % 1000000000),
-                              .tv_sec = (long)(nano_sec / 1000000000)};
+                              .tv_sec = (time_t)(nano_sec / 1000000000)};
   nanosleep(&tm, NULL);
 }
 

--- a/lib/facil/fio.h
+++ b/lib/facil/fio.h
@@ -1250,7 +1250,7 @@ inline FIO_FUNC ssize_t fio_write(const intptr_t uuid, const void *buffer,
 inline FIO_FUNC ssize_t fio_sendfile(intptr_t uuid, intptr_t source_fd,
                                      off_t offset, size_t length) {
   return fio_write2(uuid, .data.fd = source_fd, .length = length, .is_fd = 1,
-                    .offset = offset);
+                    .offset = (unsigned long)offset);
 }
 
 /**
@@ -2984,8 +2984,8 @@ FIO_FUNC inline void fio_reschedule_thread(void) {
 
 /** Nanosleep the thread - a blocking throttle. */
 FIO_FUNC inline void fio_throttle_thread(size_t nano_sec) {
-  const struct timespec tm = {.tv_nsec = (nano_sec % 1000000000),
-                              .tv_sec = (nano_sec / 1000000000)};
+  const struct timespec tm = {.tv_nsec = (long)(nano_sec % 1000000000),
+                              .tv_sec = (long)(nano_sec / 1000000000)};
   nanosleep(&tm, NULL);
 }
 

--- a/lib/facil/fiobj/fiobj4fio.h
+++ b/lib/facil/fiobj/fiobj4fio.h
@@ -14,7 +14,7 @@ static inline __attribute__((unused)) ssize_t fiobj_send_free(intptr_t uuid,
                                                               FIOBJ o) {
   fio_str_info_s s = fiobj_obj2cstr(o);
   return fio_write2(uuid, .data.buffer = (void *)(o),
-                    .offset = (unsigned long)(((intptr_t)s.data) - ((intptr_t)(o))),
+                    .offset = (uintptr_t)(((intptr_t)s.data) - ((intptr_t)(o))),
                     .length = s.len, .after.dealloc = fiobj4sock_dealloc);
 }
 

--- a/lib/facil/fiobj/fiobj4fio.h
+++ b/lib/facil/fiobj/fiobj4fio.h
@@ -14,7 +14,7 @@ static inline __attribute__((unused)) ssize_t fiobj_send_free(intptr_t uuid,
                                                               FIOBJ o) {
   fio_str_info_s s = fiobj_obj2cstr(o);
   return fio_write2(uuid, .data.buffer = (void *)(o),
-                    .offset = (((intptr_t)s.data) - ((intptr_t)(o))),
+                    .offset = (unsigned long)(((intptr_t)s.data) - ((intptr_t)(o))),
                     .length = s.len, .after.dealloc = fiobj4sock_dealloc);
 }
 


### PR DESCRIPTION
I came across this issue whilst creating a router for an API in my most recent project.
For me it was easily fixed by adding types.

Fixed issue compiling cxx14
Example: error: non-constant-expression cannot be narrowed from type
'off_t' (aka 'long') to 'uintptr_t' (aka 'unsigned long') in initializer
list [-Wc++11-narrowing]