### PR TITLE
fix deprecated API usage in boiler_plate example

### DIFF
--- a/examples/boiler_plate/src/cli.c
+++ b/examples/boiler_plate/src/cli.c
@@ -73,7 +73,7 @@ void initialize_cli(int argc, char const *argv[]) {
   if (fio_cli_get("-redis") && strlen(fio_cli_get("-redis"))) {
     FIO_LOG_INFO("* Initializing Redis connection to %s\n",
                  fio_cli_get("-redis"));
-    http_url_s info =
+    fio_url_s info =
         http_url_parse(fio_cli_get("-redis"), strlen(fio_cli_get("-redis")));
     fio_pubsub_engine_s *e =
         redis_engine_create(.address = info.host, .port = info.port,

--- a/lib/facil/http/http.h
+++ b/lib/facil/http/http.h
@@ -988,7 +988,11 @@ typedef fio_url_s http_url_s
  *
  * Invalid formats might produce unexpected results. No error testing performed.
  */
-#define http_url_parse(url, len) fio_url_parse((url), (len))
+static inline fio_url_s __attribute__((deprecated("use fio_url_parse instead")))
+http_url_parse(const char *url, size_t length)
+{
+    return fio_url_parse(url, length);
+}
 
 #if DEBUG
 void http_tests(void);

--- a/lib/facil/http/parsers/http1_parser.c
+++ b/lib/facil/http/parsers/http1_parser.c
@@ -583,13 +583,13 @@ re_eval:
                                               : args->on_request)(args->parser))
       goto error;
     args->parser->state =
-        (struct http1_parser_protected_read_only_state_s){0, 0, 0};
+        (struct http1_parser_protected_read_only_state_s){0, 0, 0, 0};
   }
   return CONSUMED;
 error:
   args->on_error(args->parser);
   args->parser->state =
-      (struct http1_parser_protected_read_only_state_s){0, 0, 0};
+      (struct http1_parser_protected_read_only_state_s){0, 0, 0, 0};
   return args->length;
 }
 

--- a/lib/facil/tls/fio_tls_missing.c
+++ b/lib/facil/tls/fio_tls_missing.c
@@ -156,7 +156,7 @@ ALPN Helpers
 
 /** Returns a pointer to the ALPN data (callback, etc') IF exists in the TLS. */
 FIO_FUNC inline alpn_s *alpn_find(fio_tls_s *tls, char *name, size_t len) {
-  alpn_s tmp = {.name = FIO_STR_INIT_STATIC2(name, len)};
+  alpn_s tmp = {.name = FIO_STR_INIT_STATIC2(name, len), NULL, NULL, NULL};
   alpn_list__map_s_ *pos =
       alpn_list__find_map_pos_(&tls->alpn, fio_str_hash(&tmp.name), tmp);
   if (!pos || !pos->pos)


### PR DESCRIPTION
 - use fio_url_s type instead of deprecated http_url_s

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>