### PR TITLE
Fix for LP32 platforms: convert pointers via uintptr_t to/from integral types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+**Fix**: fixed some 32 bit compatibility concerns. Credit to Franz Brausse ( @fbrausse ) for the [PR @ boazsegev/facil.io#96](https://github.com/boazsegev/facil.io/pull/96).
+
 ### v. 0.7.5 (2020-05-18)
 
 **Security**: backport the 0.8.x HTTP/1.1 parser and it's security updates to the 0.7.x version branch. This fixes a request smuggling attack vector and Transfer Encoding attack vector that were exposed by Sam Sanoop from [the Snyk Security team (snyk.io)](https://snyk.io). The parser was updated to deal with these potential issues.

--- a/lib/facil/cli/fio_cli.c
+++ b/lib/facil/cli/fio_cli.c
@@ -50,7 +50,7 @@ typedef struct {
 #define AVOID_MACRO
 
 #define FIO_CLI_HASH_VAL(s)                                                    \
-  fio_risky_hash((s).data, (s).len, (uint64_t)fio_cli_start)
+  fio_risky_hash((s).data, (s).len, (uintptr_t)fio_cli_start)
 
 /* *****************************************************************************
 CLI Parsing

--- a/lib/facil/fio.c
+++ b/lib/facil/fio.c
@@ -6371,7 +6371,7 @@ static inline void fio_cluster_inform_root_about_channel(channel_s *ch,
 #endif
   char buf[8] = {0};
   if (ch->match) {
-    fio_u2str64(buf, (uint64_t)ch->match);
+    fio_u2str64(buf, (uintptr_t)ch->match);
     msg.data = buf;
     msg.len = sizeof(ch->match);
   }

--- a/lib/facil/fio.h
+++ b/lib/facil/fio.h
@@ -2539,8 +2539,9 @@ FIO_FUNC inline uint64_t fio_risky_hash(const void *data_, size_t len,
   uint64_t result = fio_lrot64(v0, 17) + fio_lrot64(v1, 13) +
                     fio_lrot64(v2, 47) + fio_lrot64(v3, 57);
 
-  len ^= (len << 33);
-  result += len;
+  uint64_t len64 = len;
+  len64 ^= (len64 << 33);
+  result += len64;
 
   result += v0 * RISKY_PRIME_1;
   result ^= fio_lrot64(result, 13);

--- a/lib/facil/fiobj/fiobject.h
+++ b/lib/facil/fiobj/fiobject.h
@@ -554,11 +554,13 @@ FIO_INLINE uint64_t fiobj_obj2hash(const FIOBJ o) {
   if (!FIOBJ_IS_ALLOCATED(o))
     return (uint64_t)o;
   fio_str_info_s s = fiobj_obj2cstr(o);
-  return FIO_HASH_FN(s.data, s.len, &fiobj_each2, &fiobj_free_complex_object);
+  return FIO_HASH_FN(s.data, s.len, (uintptr_t)&fiobj_each2,
+                     (uintptr_t)&fiobj_free_complex_object);
 }
 
 FIO_INLINE uint64_t fiobj_hash_string(const void *data, size_t len) {
-  return FIO_HASH_FN(data, len, &fiobj_each2, &fiobj_free_complex_object);
+  return FIO_HASH_FN(data, len, (uintptr_t)&fiobj_each2,
+                     (uintptr_t)&fiobj_free_complex_object);
 }
 
 /**

--- a/lib/facil/redis/redis_engine.c
+++ b/lib/facil/redis/redis_engine.c
@@ -684,7 +684,7 @@ static void redis_on_publish_child(const fio_pubsub_engine_s *eng,
   fio_str_s tmp = FIO_STR_INIT;
   /* by using fio_str_s, short names are allocated on the stack */
   fio_str_info_s tmp_info = fio_str_resize(&tmp, channel.len + 8);
-  fio_u2str64(tmp_info.data, (uint64_t)eng);
+  fio_u2str64(tmp_info.data, (uintptr_t)eng);
   memcpy(tmp_info.data + 8, channel.data, channel.len);
   /* forward publication request to Root */
   fio_publish(.filter = -1, .channel = tmp_info, .message = msg,
@@ -701,7 +701,7 @@ Root Publication Handler
 static void redis_on_internal_publish(fio_msg_s *msg) {
   if (msg->channel.len < 8)
     return; /* internal error, unexpected data */
-  void *en = (void *)fio_str2u64(msg->channel.data);
+  void *en = (void *)(uintptr_t)fio_str2u64(msg->channel.data);
   if (en != msg->udata1)
     return; /* should be delivered by a different engine */
   /* step after the engine data */
@@ -721,8 +721,8 @@ Sending commands using the Root connection
 static void redis_forward_reply(fio_pubsub_engine_s *e, FIOBJ reply,
                                 void *udata) {
   uint8_t *data = udata;
-  fio_pubsub_engine_s *engine = (fio_pubsub_engine_s *)fio_str2u64(data + 0);
-  void *callback = (void *)fio_str2u64(data + 8);
+  fio_pubsub_engine_s *engine = (fio_pubsub_engine_s *)(uintptr_t)fio_str2u64(data + 0);
+  void *callback = (void *)(uintptr_t)fio_str2u64(data + 8);
   if (engine != e || !callback) {
     FIO_LOG_DEBUG("Redis reply not forwarded (callback: %p)", callback);
     return;
@@ -738,7 +738,7 @@ static void redis_forward_reply(fio_pubsub_engine_s *e, FIOBJ reply,
 static void redis_on_internal_cmd(fio_msg_s *msg) {
   // void*(void *)fio_str2u64(msg->msg.data);
   fio_pubsub_engine_s *engine =
-      (fio_pubsub_engine_s *)fio_str2u64(msg->channel.data + 0);
+      (fio_pubsub_engine_s *)(uintptr_t)fio_str2u64(msg->channel.data + 0);
   if (engine != msg->udata1) {
     return;
   }
@@ -756,7 +756,7 @@ static void redis_on_internal_cmd(fio_msg_s *msg) {
 /* Listens on filter `-10 -getpid()` for incoming reply data */
 static void redis_on_internal_reply(fio_msg_s *msg) {
   fio_pubsub_engine_s *engine =
-      (fio_pubsub_engine_s *)fio_str2u64(msg->channel.data + 0);
+      (fio_pubsub_engine_s *)(uintptr_t)fio_str2u64(msg->channel.data + 0);
   if (engine != msg->udata1) {
     FIO_LOG_DEBUG("Redis reply not forwarded (engine mismatch: %p != %p)",
                   (void *)engine, msg->udata1);
@@ -765,8 +765,8 @@ static void redis_on_internal_reply(fio_msg_s *msg) {
   FIOBJ reply;
   fiobj_json2obj(&reply, msg->msg.data, msg->msg.len);
   void (*callback)(fio_pubsub_engine_s *, FIOBJ, void *) = (void (*)(
-      fio_pubsub_engine_s *, FIOBJ, void *))fio_str2u64(msg->channel.data + 8);
-  void *udata = (void *)fio_str2u64(msg->channel.data + 16);
+      fio_pubsub_engine_s *, FIOBJ, void *))(uintptr_t)fio_str2u64(msg->channel.data + 8);
+  void *udata = (void *)(uintptr_t)fio_str2u64(msg->channel.data + 16);
   callback(engine, reply, udata);
   fiobj_free(reply);
 }
@@ -788,9 +788,9 @@ intptr_t redis_engine_send(fio_pubsub_engine_s *engine, FIOBJ command,
   fio_str_s tmp = FIO_STR_INIT;
   fio_str_info_s ti = fio_str_resize(&tmp, 28);
   /* combine metadata */
-  fio_u2str64(ti.data + 0, (uint64_t)engine);
-  fio_u2str64(ti.data + 8, (uint64_t)callback);
-  fio_u2str64(ti.data + 16, (uint64_t)udata);
+  fio_u2str64(ti.data + 0, (uintptr_t)engine);
+  fio_u2str64(ti.data + 8, (uintptr_t)callback);
+  fio_u2str64(ti.data + 16, (uintptr_t)udata);
   fio_u2str32(ti.data + 24, (uint32_t)getpid());
   FIOBJ cmd = fiobj2resp_tmp(command);
   fio_publish(.filter = -2, .channel = ti, .message = fiobj_obj2cstr(cmd),

--- a/makefile
+++ b/makefile
@@ -70,6 +70,9 @@ INCLUDE= ./
 # any preprocessosr defined flags we want, space seperated list (i.e. DEBUG )
 FLAGS:=
 
+# we use sendfile64() and off_t
+override FLAGS += _FILE_OFFSET_BITS=64
+
 # c compiler
 ifndef CC
 	CC=gcc


### PR DESCRIPTION
Hi,

I'm using facil.io on a i686 Linux machine (gcc-9.3.0) and noticed lots of warnings about casting pointers to integers of different widths, e.g. `(uint64_t)&obj`, an (undefined) left-shift of a 32-bit `size_t` by 33 in the risky hash computation, as well as the explicit use of `sendfile64` with an `off_t` parameter.

This patch fixes these warnings by
* casting pointers to `uintptr_t` first,
* using an intermediate `uint64_t` for the risky hash mixing in of `size_t len`, and
* unconditionally adding the `_FILE_OFFSET_BITS=64` #define to the `FLAGS` in `makefile`.

The API has not been touched, just the internal calls. This has been the most obvious way for me to fix compilation of facil.io on this 32-bit platform, though I'm open to fixing these in a different way if you have any suggestions.