### PR TITLE
docs: fix simple typo, previosly -> previously

### DIFF
--- a/docs/_SOURCE/0.7.x/fiobj_str.md
+++ b/docs/_SOURCE/0.7.x/fiobj_str.md
@@ -54,7 +54,7 @@ FIOBJ fiobj_str_move(char *str, size_t len, size_t capacity);
 
 Creates a String object. Remember to use `fiobj_free`.
 
-It's possible to wrap a previosly allocated memory block in a FIOBJ String object, as long as it was allocated using `fio_malloc`.
+It's possible to wrap a previously allocated memory block in a FIOBJ String object, as long as it was allocated using `fio_malloc`.
 
 The ownership of the memory indicated by `str` will "move" to the object and will be freed (using `fio_free`) once the object's reference count drops to zero.
 

--- a/lib/facil/fiobj/fiobj_str.c
+++ b/lib/facil/fiobj/fiobj_str.c
@@ -152,7 +152,7 @@ FIOBJ fiobj_str_new(const char *str, size_t len) {
 /**
  * Creates a String object. Remember to use `fiobj_free`.
  *
- * It's possible to wrap a previosly allocated memory block in a FIOBJ String
+ * It's possible to wrap a previously allocated memory block in a FIOBJ String
  * object, as long as it was allocated using `fio_malloc`.
  *
  * The ownership of the memory indicated by `str` will "move" to the object and

--- a/lib/facil/fiobj/fiobj_str.h
+++ b/lib/facil/fiobj/fiobj_str.h
@@ -38,7 +38,7 @@ static inline __attribute__((unused)) FIOBJ fiobj_str_copy(FIOBJ src) {
 /**
  * Creates a String object. Remember to use `fiobj_free`.
  *
- * It's possible to wrap a previosly allocated memory block in a FIOBJ String
+ * It's possible to wrap a previously allocated memory block in a FIOBJ String
  * object, as long as it was allocated using `fio_malloc`.
  *
  * The ownership of the memory indicated by `str` will "move" to the object and


### PR DESCRIPTION
There is a small typo in docs/_SOURCE/0.7.x/fiobj_str.md, lib/facil/fiobj/fiobj_str.c, lib/facil/fiobj/fiobj_str.h.

Should read `previously` rather than `previosly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md