### PR TITLE
Make tests run by default

### DIFF
--- a/lib/facil/fio.c
+++ b/lib/facil/fio.c
@@ -3917,23 +3917,31 @@ void fio_start FIO_IGNORE_MACRO(struct fio_start_args args) {
   fio_data->is_worker = 0;
 
   fio_state_callback_force(FIO_CALL_PRE_START);
+#if HAVE_OPENSSL
   FIO_LOG_INFO(
       "Server is running %u %s X %u %s with facil.io " FIO_VERSION_STRING
       " (%s)\n"
-#if HAVE_OPENSSL
       "* Linked to %s\n"
-#endif
       "* Detected capacity: %d open file limit\n"
       "* Root pid: %d\n"
       "* Press ^C to stop\n",
       fio_data->workers, fio_data->workers > 1 ? "workers" : "worker",
       fio_data->threads, fio_data->threads > 1 ? "threads" : "thread",
       fio_engine(),
-#if HAVE_OPENSSL
       OpenSSL_version(0),
-#endif
       fio_data->capa, (int)fio_data->parent);
-
+#else
+  FIO_LOG_INFO(
+      "Server is running %u %s X %u %s with facil.io " FIO_VERSION_STRING
+      " (%s)\n"
+      "* Detected capacity: %d open file limit\n"
+      "* Root pid: %d\n"
+      "* Press ^C to stop\n",
+      fio_data->workers, fio_data->workers > 1 ? "workers" : "worker",
+      fio_data->threads, fio_data->threads > 1 ? "threads" : "thread",
+      fio_engine(),
+      fio_data->capa, (int)fio_data->parent);
+#endif
   if (args.workers > 1) {
     for (int i = 0; i < args.workers && fio_data->active; ++i) {
       fio_sentinel_task(NULL, NULL);

--- a/makefile
+++ b/makefile
@@ -64,7 +64,7 @@ LINKER_LIBS=pthread m
 # optimization level.
 OPTIMIZATION=-O2 -march=native
 # Warnings... i.e. -Wpedantic -Weverything -Wno-format-pedantic
-WARNINGS= -Wshadow -Wall -Wextra -Wno-missing-field-initializers -Wpedantic
+WARNINGS= -Wshadow -Wall -Wextra -Wno-missing-field-initializers -Wpedantic -Wno-error=cast-function-type
 # any extra include folders, space seperated list. (i.e. `pg_config --includedir`)
 INCLUDE= ./
 # any preprocessosr defined flags we want, space seperated list (i.e. DEBUG )


### PR DESCRIPTION
Fixing "cast between incompatible function types from" for good would need some changes.
For example:
 changing
```
 struct fio_packet_s {
  fio_packet_s *next;
  int (*write_func)(int fd, struct fio_packet_s *packet);
  void (*dealloc)(void *buffer);
  union {
    void *buffer;
    intptr_t fd;
  } data;
  uintptr_t offset;
  uintptr_t length;
};
```

to:
```
 struct fio_packet_s {
  fio_packet_s *next;
  int (*write_func)(int fd, struct fio_packet_s *packet);
  union {
    void (*dealloc_buf)(void *buffer);
    void (*dealloc_fd)(intptr_t fd);
  } dealloc;
  union {
    void *buffer;
    intptr_t fd;
  } data;
  uintptr_t offset;
  uintptr_t length;
};
```
and match references accordingly. I would implement that, if that is ok for you?