### PR TITLE
Improve handling of intermediate certificates in public key for SSL_CTX configuration

### DIFF
--- a/lib/facil/tls/fio_tls_openssl.c
+++ b/lib/facil/tls/fio_tls_openssl.c
@@ -423,7 +423,11 @@ static void fio_tls_build_context(fio_tls_s *tls) {
             X509_INFO *tmp = sk_X509_INFO_value(inf, i);
             if (tmp->x509) {
               FIO_LOG_DEBUG("TLS adding certificate from PEM file.");
-              SSL_CTX_use_certificate(tls->ctx, tmp->x509);
+              if (i == 0) {
+                SSL_CTX_use_certificate(tls->ctx, tmp->x509);
+              } else {
+                SSL_CTX_add1_chain_cert(tls->ctx, tmp->x509);
+              }
             }
             if (tmp->x_pkey) {
               FIO_LOG_DEBUG("TLS adding private key from PEM file.");


### PR DESCRIPTION
The current code in the for loop does not properly add the intermediate certificates from the PEM file to the SSL_CTX. When a certificate provider, such as Let's Encrypt, supplies a fullchain.pem file containing both the server certificate and the intermediate certificate(s), the existing code only includes the server certificate. This leads to an improperly configured SSL handshake.

Commenting out the for loop, as suggested in the related issue on the iodine repo (https://github.com/boazsegev/iodine/issues/94), does not resolve the problem. 

An alternative solution is to use SSL_CTX_use_certificate_chain_file(), which can handle the inclusion of intermediate certificates. However, this approach requires modifying the current functions to pass the PEM file name instead of the public_key contents.

To address this issue, I propose the following changes:

Set the server certificate in the SSL_CTX using the initial X509 value from the public_key.
Iterate through the remaining X509 values (if any) and add them to the SSL_CTX using SSL_CTX_add1_chain_cert(). This function is specifically designed to add additional certificates to the certificate chain.

By making these modifications, the SSL_CTX will be properly configured with both the server certificate and any intermediate certificates present in the PEM file.

With this code change we were able to confirm a properly configured SSL certificate from our server environment. 

References:

SSL_CTX_use_certificate_chain_file(): https://www.openssl.org/docs/manmaster/man3/SSL_CTX_use_certificate_chain_file.html

SSL_CTX_add1_chain_cert(): https://www.openssl.org/docs/man3.0/man3/SSL_CTX_add1_chain_cert.html

Please let me know if you have any questions or requests with this change!