### PR TITLE
Fix typos in main documentation (docs/_SOURCE, docs/_SOURCE/0.7.x)

### DIFF
--- a/docs/_SOURCE/0.7.x/extensions.md
+++ b/docs/_SOURCE/0.7.x/extensions.md
@@ -10,7 +10,7 @@ However, there are many tasks that are common to applications that need an event
 
 These bundled extensions to the core library provide common functionality. They aren't required and can be safely deleted without effecting the core library.
 
-The following extensions come bundled along with facio.io:
+The following extensions come bundled along with facil.io:
 
 * The [TLS (`fio_tls`)](fio_tls) extension for adding SSL/TLS support (requires 3rd party libraries).
 

--- a/docs/_SOURCE/0.7.x/fio.md
+++ b/docs/_SOURCE/0.7.x/fio.md
@@ -137,7 +137,7 @@ Attaches (or updates) a protocol object to a file descriptor (fd).
 
 The new protocol object can be NULL, which will detach ("hijack") the socket.
 
-The `fd` can be one created outside of facil.io if it was set in to non-blocking mode (see [`fio_set_non_block`](#fio_set_non_block)).
+The `fd` can be one created outside of facil.io if it was set to non-blocking mode (see [`fio_set_non_block`](#fio_set_non_block)).
 
 The old protocol's `on_close` (if any) will be scheduled.
 
@@ -188,7 +188,7 @@ void fio_touch(intptr_t uuid);
 #### `fio_force_event`
 
 ```c
-void fio_force_event(intptr_t uuid, enum fio_io_event);
+void fio_force_event(intptr_t uuid, enum fio_io_event event);
 ```
 
 Schedules an IO event, even if it did not occur.
@@ -432,7 +432,7 @@ The following arguments are supported:
         // callback example:
         void on_connect(intptr_t uuid, void *udata);
 
-* `on_connect`:
+* `on_fail`:
 
     This callback will be called when a socket fails to connect. It's often a good place for cleanup.
 
@@ -764,7 +764,7 @@ void fio_close(intptr_t uuid);
 
 `fio_close` marks the connection for disconnection once all the data was sent. The actual disconnection will be managed by the [`fio_flush`](#fio_flush) function.
 
-[`fio_flash`](#fio_flash) will be automatically scheduled.
+[`fio_flush`](#fio_flush) will be automatically scheduled.
 
 #### `fio_force_close`
 
@@ -2407,7 +2407,7 @@ Takes a UTF-8 character selection information (UTF-8 position and length) and up
 
 If the String isn't UTF-8 valid up to the requested selection, than `pos` will be updated to `-1` otherwise values are always positive.
 
-The returned `len` value may be shorter than the original if there wasn't enough data left to accomodate the requested length. When a `len` value of `0` is returned, this means that `pos` marks the end of the String.
+The returned `len` value may be shorter than the original if there wasn't enough data left to accommodate the requested length. When a `len` value of `0` is returned, this means that `pos` marks the end of the String.
 
 Returns -1 on error and 0 on success.
 
@@ -3969,7 +3969,7 @@ A SHA-2 helper function that performs initialization, writing and finalizing.
 
 Uses the SHA2 256 variant.
 
-#### `fio_sha2_256`
+#### `fio_sha2_384`
 
 ```c
 inline char *fio_sha2_384(fio_sha2_s *s, const void *data,

--- a/docs/_SOURCE/0.7.x/fiobj_ary.md
+++ b/docs/_SOURCE/0.7.x/fiobj_ary.md
@@ -134,7 +134,7 @@ remember to `fiobj_free` the old object.
 int64_t fiobj_ary_find(FIOBJ ary, FIOBJ data);
 ```
 
-Finds the index of a specifide object (if any). Returns -1 if the object
+Finds the index of a specified object (if any). Returns -1 if the object
 isn't found.
 
 #### `fiobj_ary_remove`

--- a/docs/_SOURCE/0.7.x/fiobj_core.md
+++ b/docs/_SOURCE/0.7.x/fiobj_core.md
@@ -176,7 +176,7 @@ typedef struct fio_str_info_s {
 The Sting in binary safe and might contain NUL bytes in the middle as well as
 a terminating NUL.
 
-If a a Number or a Float are passed to the function, they
+If a Number or a Float is passed to the function, they
 will be parsed as a *temporary*, thread-safe, String.
 
 Numbers will be represented in base 10 numerical data.

--- a/docs/_SOURCE/0.7.x/fiobj_json.md
+++ b/docs/_SOURCE/0.7.x/fiobj_json.md
@@ -129,7 +129,7 @@ FIOBJ fiobj_obj2json2(FIOBJ dest, FIOBJ object, uint8_t pretty);
 
 Formats an object into a JSON string, appending the JSON string to an existing String. Remember to `fiobj_free` as usual.
 
-Note that only the foloowing basic fiobj types are supported: Primitives (True / False / NULL), Numbers (Number / Float), Strings, Hashes and Arrays.
+Note that only the following basic fiobj types are supported: Primitives (True / False / NULL), Numbers (Number / Float), Strings, Hashes and Arrays.
  
 Some objects (such as the POSIX specific IO type) are unsupported and may be formatted incorrectly.
  

--- a/docs/_SOURCE/0.7.x/http.md
+++ b/docs/_SOURCE/0.7.x/http.md
@@ -4,7 +4,7 @@ sidebar: 0.7.x/_sidebar.md
 ---
 # {{{title}}}
 
-facil.io includes an HTTP/1.1 and WebSocket server / framework that could be used to author HTTP and WebSocket services, including REST applications, micro-services, etc'.
+facil.io includes an HTTP/1.1 and WebSocket server / framework that could be used to author HTTP and WebSocket services, including REST applications, micro-services, etc.
 
 Note that, currently, only HTTP/1.1 is supported. Support for HTTP/2 is planned for future versions and could be implemented as a custom protocol until such time.
 
@@ -45,7 +45,7 @@ In addition to the `port` and `address` argument (explained in [`fio_listen`](fi
         // callback example:
         void on_request(http_s *request);
 
-* `on_request`:
+* `on_upgrade`:
 
     Callback for Upgrade and EventSource (SSE) requests.
 
@@ -54,7 +54,7 @@ In addition to the `port` and `address` argument (explained in [`fio_listen`](fi
         // callback example:
         void on_upgrade(http_s *request, char *requested_protocol, size_t len);
 
-* `on_request`:
+* `on_response`:
 
     This callback is ignored for HTTP server mode and is only called when a response (not a request) is received. On server connections, this would normally indicate a protocol error.
 
@@ -245,7 +245,7 @@ typedef struct {
 } http_s;
 ```
 
-The `http_s` data in NOT thread safe and can only be accessed safely from within the HTTP callbacks (`on_request`, `on_response` and the `http_defer` callback)
+The `http_s` data is NOT thread safe and can only be accessed safely from within the HTTP callbacks (`on_request`, `on_response` and the `http_defer` callback)
 
 ### HTTP Handle Data Access
 
@@ -514,7 +514,7 @@ In addition to the handle argument (`http_s *`), the following arguments are sup
         // type:
        unsigned secure : 1;
 
-* `path_len`:
+* `http_only`:
 
      Limit cookie to HTTP (intended to prevent JavaScript access/hijacking).
 

--- a/docs/_SOURCE/0.7.x/index.md
+++ b/docs/_SOURCE/0.7.x/index.md
@@ -10,7 +10,7 @@ A Web application in C? It's as easy as:
 ```c
 #include "http.h" /* the HTTP facil.io extension */
 
-// We'll use this callback in `http_listen`, to handles HTTP requests
+// We'll use this callback in `http_listen`, to handle HTTP requests
 void on_request(http_s *request);
 
 // These will contain pre-allocated values that we will use often

--- a/docs/_SOURCE/0.7.x/riskyhash.md
+++ b/docs/_SOURCE/0.7.x/riskyhash.md
@@ -12,7 +12,7 @@ Risky Hash wasn't properly tested for attack resistance and shouldn't be used wi
 
 Risky Hash was tested with [`SMHasher`](https://github.com/rurban/smhasher) ([see results](#smhasher-results)) (passed).
 
-A non-streaming [reference implementation in C is attached](#in-code) The code is easy to read and should be considered an integral part of this specification.
+A non-streaming [reference implementation in C is attached](#in-code). The code is easy to read and should be considered an integral part of this specification.
 
 ## Status
 
@@ -26,7 +26,7 @@ This is the second draft of the RiskyHash algorithm and it incorporates updates 
 
     Following this feedback, the error in the code was fixed, the initialization state was updated and the left-over bytes are now read in order with padding (rather than consumed by the 4th state-word).
 
-* Chris Anderson (@injinj) did amazing work exploring a 128 bit variation and attacking RiskyHash using a variation on a Meet-In-The-Middle attack, written by Hening Makholm (@hmakholm), that discovers hash collisions with a small Hamming distance ([SMHasher fork](https://github.com/hmakholm/smhasher)).
+* Chris Anderson (@injinj) did amazing work exploring a 128 bit variation and attacking RiskyHash using a variation on a Meet-In-The-Middle attack, written by Henning Makholm (@hmakholm), that discovers hash collisions with a small Hamming distance ([SMHasher fork](https://github.com/hmakholm/smhasher)).
 
     Following this input, RiskyHash updated the way the message length is incorporated into the final hash and updated the consumption stage to replace the initial XOR with ADD.
 

--- a/docs/_SOURCE/0.7.x/riskyhash_v1.md
+++ b/docs/_SOURCE/0.7.x/riskyhash_v1.md
@@ -12,7 +12,7 @@ Risky Hash wasn't properly tested for attack resistance and shouldn't be used wi
 
 Risky Hash was tested with [`SMHasher`](https://github.com/rurban/smhasher) ([see results](#smhasher-results)) (passed).
 
-A non-streaming [reference implementation in C is attached](#in-code) The code is easy to read and should be considered as the actual specification.
+A non-streaming [reference implementation in C is attached](#in-code). The code is easy to read and should be considered as the actual specification.
 
 ## Status
 
@@ -186,7 +186,7 @@ Risky Hash attempts to balance performance with security concerns, since hash fu
 
 However, the design should allow for fairly high performance, for example, by using SIMD instructions or a multi-threaded approach (up to 4 threads).
 
-In fact, even the simple reference implementation at the end of this document offers fairly high performance, averaging 17% faster than xxHash for short keys (up to 31 bytes) and 9% slower on long keys (262,144 bytes).
+In fact, even the simple reference implementation at the end of this document offers fairly high performance, averaging 17% faster than xxHash for short keys (up to 31 bytes) and 9% slower on long keys (262.144 bytes).
 
 ## Attacks, Reports and Security
 

--- a/docs/_SOURCE/index.md
+++ b/docs/_SOURCE/index.md
@@ -29,7 +29,7 @@ I used this library (including the HTTP server) on Linux, Mac OS X and FreeBSD (
 ```c
 #include "http.h" /* the HTTP facil.io extension */
 
-// We'll use this callback in `http_listen`, to handles HTTP requests
+// We'll use this callback in `http_listen`, to handle HTTP requests
 void on_request(http_s *request);
 
 // These will contain pre-allocated values that we will use often


### PR DESCRIPTION
This PR fixes several typos, punctuation errors, and minor wording issues in the main documentation under:

- docs/_SOURCE
- docs/_SOURCE/0.7.x

I focused only on correcting text (spelling, grammar, punctuation) and did not modify function definitions or code snippets.